### PR TITLE
Support Storyboard object IDs as keys

### DIFF
--- a/miaw
+++ b/miaw
@@ -81,7 +81,7 @@ def generate_keys_file(opts)
     end
   
     f.write(" */\n")
-    f.write("static NSString * const #{key.gsub("%", "").gsub("@", "X")} = @\"#{ key }\";\n\n")
+    f.write("static NSString * const #{key.gsub("%", "").gsub("@", "X").gsub(".", "_").gsub(/^[\d]/, 'n\0')} = @\"#{ key }\";\n\n")
   end
 
   f.write("                                               \n")


### PR DESCRIPTION
Convert . (dot) to _ (underscore). E.g. "label.text" => "label_text"
If first character is number (\d), convert to "n" + "number". E.g. "3fi-xX-nld" => "n3fi-xX-nld"

This makes storyboard object IDs valid static keys
