### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ An essential part of MiawKit is the ``miaw`` command line utility itself. It is 
 static NSString * const RK_FACEBOOK_INVITE_TITLE = @"RK_FACEBOOK_INVITE_TITLE";
 ```
 
-XCode is even smart enough to show you the documentation so you can see the translation for a key by alt-clicking any localization key constant.
+Xcode is even smart enough to show you the documentation so you can see the translation for a key by alt-clicking any localization key constant.
 
 ![](http://f.cl.ly/items/3K0p2Z3D1t2h013p1p17/Screen%20Shot%202014-05-13%20at%2011.42.32.png)
 


### PR DESCRIPTION
This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
